### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Core loop results are reported ( FSE_compress_usingCTable() & FSE_decompress_usi
 *Speed is provided in MS/s (Millions of Symbols per second).
 For more detailed results, browse the [benchmark results](benchmarkResults)*
 
-As an obvious outcome, speed of FSE is stable accross all tested file.
+As an obvious outcome, speed of FSE is stable across all tested file.
 By design, Huffman can't break the "1 bit per symbol" limit.
 FSE is free of such limit, so its performance increase with probability, remaining close to Shannon limit.
 


### PR DESCRIPTION
@Cyan4973, I've corrected a typographical error in the documentation of the [FiniteStateEntropy](https://github.com/Cyan4973/FiniteStateEntropy) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.