### PR TITLE
Make tuning parameters configurable without changing the source code

### DIFF
--- a/lib/fse.h
+++ b/lib/fse.h
@@ -581,14 +581,19 @@ MEM_STATIC unsigned FSE_endOfDState(const FSE_DState_t* DStatePtr)
 *  Increasing memory usage improves compression ratio
 *  Reduced memory usage can improve speed, due to cache effect
 *  Recommended max value is 14, for 16KB, which nicely fits into Intel x86 L1 cache */
-#define FSE_MAX_MEMORY_USAGE 14
-#define FSE_DEFAULT_MEMORY_USAGE 13
+#ifndef FSE_MAX_MEMORY_USAGE
+#  define FSE_MAX_MEMORY_USAGE 14
+#endif
+#ifndef FSE_DEFAULT_MEMORY_USAGE
+#  define FSE_DEFAULT_MEMORY_USAGE 13
+#endif
 
 /*!FSE_MAX_SYMBOL_VALUE :
 *  Maximum symbol value authorized.
 *  Required for proper stack allocation */
-#define FSE_MAX_SYMBOL_VALUE 255
-
+#ifndef FSE_MAX_SYMBOL_VALUE
+#  define FSE_MAX_SYMBOL_VALUE 255
+#endif
 
 /* **************************************************************
 *  template functions type & suffix

--- a/lib/fseU16.c
+++ b/lib/fseU16.c
@@ -40,17 +40,20 @@
 *  Increasing memory usage improves compression ratio
 *  Reduced memory usage can improve speed, due to cache effect
 *  Recommended max value is 14, for 16KB, which nicely fits into Intel x86 L1 cache */
-#define FSE_MAX_MEMORY_USAGE 15
-#define FSE_DEFAULT_MEMORY_USAGE 14
-
+#ifndef FSEU16_MAX_MEMORY_USAGE
+#  define FSEU16_MAX_MEMORY_USAGE 15
+#endif
+#ifndef FSEU16_DEFAULT_MEMORY_USAGE
+#  define FSEU16_DEFAULT_MEMORY_USAGE 14
+#endif
 
 /* **************************************************************
 *  Includes
 *****************************************************************/
 #include "fseU16.h"
 #define FSEU16_SYMBOLVALUE_ABSOLUTEMAX 4095
-#if (FSE_MAX_SYMBOL_VALUE > FSEU16_SYMBOLVALUE_ABSOLUTEMAX)
-#  error "FSE_MAX_SYMBOL_VALUE is too large !"
+#if (FSEU16_MAX_SYMBOL_VALUE > FSEU16_SYMBOLVALUE_ABSOLUTEMAX)
+#  error "FSEU16_MAX_SYMBOL_VALUE is too large !"
 #endif
 
 /* **************************************************************
@@ -83,6 +86,15 @@ typedef struct {
 *  Include type-specific functions from fse.c (C template emulation)
 *********************************************************************/
 #define FSE_COMMONDEFS_ONLY
+
+#ifdef FSE_MAX_MEMORY_USAGE
+#  undef FSE_MAX_MEMORY_USAGE
+#endif
+#ifdef FSE_DEFAULT_MEMORY_USAGE
+#  undef FSE_DEFAULT_MEMORY_USAGE
+#endif
+#define FSE_MAX_MEMORY_USAGE FSEU16_MAX_MEMORY_USAGE
+#define FSE_DEFAULT_MEMORY_USAGE FSEU16_DEFAULT_MEMORY_USAGE
 
 #define FSE_FUNCTION_TYPE U16
 #define FSE_FUNCTION_EXTENSION U16

--- a/lib/fseU16.h
+++ b/lib/fseU16.h
@@ -45,8 +45,13 @@ extern "C" {
 /* FSE_MAX_SYMBOL_VALUE :
 *  Maximum nb of symbol values authorized.
 *  Required for allocation purposes */
-#define FSE_MAX_SYMBOL_VALUE 286   /* This is just an example, typical value for zlib */
-
+#ifndef FSEU16_MAX_SYMBOL_VALUE
+#  define FSEU16_MAX_SYMBOL_VALUE 286   /* This is just an example, typical value for zlib */
+#endif
+#ifdef FSE_MAX_SYMBOL_VALUE
+#  undef FSE_MAX_SYMBOL_VALUE
+#endif
+#define FSE_MAX_SYMBOL_VALUE FSEU16_MAX_SYMBOL_VALUE
 
 /*-*****************************************
 *  Includes


### PR DESCRIPTION
There was a need to change some tuning parameters without touching the source files directly. This PR makes possible to provide these values using compiler parameters.

Introduced separate FSEU16_x constants for U16 operations. Otherwise it wouldn't be possible to configure U16 operations separately.
