### PR TITLE
Fix warnings from 141 toolset to allow build under Vistual Studio 2017

### DIFF
--- a/programs/bench.c
+++ b/programs/bench.c
@@ -114,7 +114,7 @@ static int BMK_tableLog = 12;
 
 void BMK_SetByteCompressor(int id) { BMK_byteCompressor = id; }
 
-void BMK_SetBlocksize(U32 bsize) { chunkSize = bsize; DISPLAY("- Blocks %i KB -\n", chunkSize>>10); }
+void BMK_SetBlocksize(U32 bsize) { chunkSize = bsize; DISPLAY("- Blocks %u KB -\n", chunkSize>>10); }
 
 void BMK_SetTableLog(int tableLog) { BMK_tableLog = 5 + tableLog; }
 

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -227,6 +227,8 @@ static void get_fileHandle(const char* input_filename, const char* output_filena
         *pfinput = fopen(input_filename, "rb");
     }
 
+    if (*pfinput == 0) EXM_THROW(12, "Pb opening %s", input_filename);
+
     if (!strcmp (output_filename, stdoutmark)) {
         DISPLAYLEVEL(4,"Using stdout for output\n");
         *pfoutput = stdout;
@@ -249,7 +251,6 @@ static void get_fileHandle(const char* input_filename, const char* output_filena
         *pfoutput = fopen( output_filename, "wb" );
     }
 
-    if ( *pfinput==0 ) EXM_THROW(12, "Pb opening %s", input_filename);
     if ( *pfoutput==0) EXM_THROW(13, "Pb opening %s", output_filename);
 }
 
@@ -547,6 +548,7 @@ unsigned long long FIO_decompressFilename(const char* output_filename, const cha
             break;
           default :
           case bt_crc :
+            cSize = 0;
             assert(0);   /* supposed already eliminated at this stage */
         }
 

--- a/programs/xxhash.c
+++ b/programs/xxhash.c
@@ -52,7 +52,7 @@
 #ifndef XXH_FORCE_MEMORY_ACCESS   /* can be defined externally, on command line for example */
 #  if defined(__GNUC__) && ( defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) || defined(__ARM_ARCH_6K__) || defined(__ARM_ARCH_6Z__) || defined(__ARM_ARCH_6ZK__) || defined(__ARM_ARCH_6T2__) )
 #    define XXH_FORCE_MEMORY_ACCESS 2
-#  elif defined(__INTEL_COMPILER) || \
+#  elif (defined(__INTEL_COMPILER) && !_WIN32) || \
   (defined(__GNUC__) && ( defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7R__) || defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7S__) ))
 #    define XXH_FORCE_MEMORY_ACCESS 1
 #  endif


### PR DESCRIPTION
* Fix warning C4701 to allow build under 141 toolset
* Fix Intel (windows) compiler error 
* Throw an error if input file handler is invalid without parsing output file