### PR TITLE
Add GitHub Actions for all supported platforms.

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -1,0 +1,112 @@
+name: make
+
+on:
+  pull_request:
+    branches: [ dev ]
+  push:
+
+jobs:
+  make-test-macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: clangtest
+      run: make clangtest
+
+    - name: test
+      run: make test
+
+    - name: sanitize
+      run: make sanitize
+
+    - name: max13test
+      run: make max13test
+
+  make-test-ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup environment
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -qq clang
+        sudo apt-get install -qq g++-multilib
+        sudo apt-get install -qq gcc-multilib
+        sudo apt-get install -qq valgrind
+        sudo apt-get install -qq make
+        sudo apt-get install -qq gcc-arm-linux-gnueabi
+
+    - name: clangtest
+      run: make clangtest
+
+    - name: armtest
+      run: make armtest
+
+    - name: gpptest
+      run: make gpptest
+
+    - name: test
+      run: make test
+
+    - name: sanitize
+      run: make sanitize
+
+    - name: max13test
+      run: make max13test
+
+  make-test-windows:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false  # 'false' means Don't stop matrix workflows even if some matrix failed.
+      matrix:
+        include: [
+          { compiler: gcc, cpp_compiler: g++, msystem: MINGW64 },
+          { compiler: clang, cpp_compiler: clang++, msystem: MINGW64 },
+        ]
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: msys2/setup-msys2@cc11e9188b693c2b100158c3322424c4cc1dadea # tag=v2.22.0
+      with:
+        msystem: ${{ matrix.msystem }}
+        install: make diffutils
+        update: true
+
+    # Based on https://ariya.io/2020/07/on-github-actions-with-msys2
+    - name: install mingw gcc x86_64
+      if: ${{ (matrix.compiler == 'gcc') }}
+      run: pacman --noconfirm -S mingw-w64-x86_64-gcc
+
+    - name: install mingw clang x86_64
+      if: ${{ (matrix.compiler == 'clang') }}
+      run: pacman --noconfirm -S mingw-w64-x86_64-clang
+
+    - name: clangtest
+      if: ${{ (matrix.compiler == 'clang') }}
+      run: |
+        export CC=${{ matrix.compiler }}
+        export CXX=${{ matrix.cpp_compiler }}
+        make clangtest
+
+    - name: gpptest
+      if: ${{ (matrix.compiler == 'gcc') }}
+      run: |
+        export CC=${{ matrix.compiler }}
+        export CXX=${{ matrix.cpp_compiler }}
+        make gpptest
+
+    - name: test
+      run: |
+        export CC=${{ matrix.compiler }}
+        export CXX=${{ matrix.cpp_compiler }}
+        make test
+
+    - name: max13test
+      run: |
+        export CC=${{ matrix.compiler }}
+        export CXX=${{ matrix.cpp_compiler }}
+        make max13test

--- a/programs/commandline.c
+++ b/programs/commandline.c
@@ -52,7 +52,9 @@
 #  include <fcntl.h>    /* _O_BINARY */
 #  include <io.h>       /* _setmode, _isatty */
 #  ifdef __MINGW32__
+#  if ((!defined(__clang__)) && __GNUC__ < 9) || (defined(__clang__) && __clang_major__ < 10)
    int _fileno(FILE *stream);   /* MINGW somehow forgets to include this windows declaration into <stdio.h> */
+#  endif
 #  endif
 #  define SET_BINARY_MODE(file) _setmode(_fileno(file), _O_BINARY)
 #  define IS_CONSOLE(stdStream) _isatty(_fileno(stdStream))

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -68,7 +68,9 @@
 #  include <fcntl.h>    // _O_BINARY
 #  include <io.h>       // _setmode, _isatty
 #  ifdef __MINGW32__
+#  if ((!defined(__clang__)) && __GNUC__ < 9) || (defined(__clang__) && __clang_major__ < 10)
    int _fileno(FILE *stream);   // MINGW somehow forgets to include this windows declaration into <stdio.h>
+#  endif
 #  endif
 #  define SET_BINARY_MODE(file) { int unused = _setmode(_fileno(file), _O_BINARY); (void)unused; }
 #  define IS_CONSOLE(stdStream) _isatty(_fileno(stdStream))


### PR DESCRIPTION
Hello.

Based on a Travis script - GitHub Actions script was created and proposed for the merge.
macOS and Ubuntu use direct transformation.
As for the Windows - approach [from zstd repository](https://github.com/facebook/zstd/blob/bb4f85d/.github/workflows/dev-short-tests.yml#L436) was took and combine with direct steps.

To made [first run success](https://github.com/TheVice/FiniteStateEntropy/actions/runs/8218771403) - addition changes was required to made at the _commandline.c_ and _fileio.c_ files.
That changes required for success compile on Windows platform by gcc and clang compilers provided by MSYS2.
Probably that "monster" macros checking is not welcome, but I need permission to drop support of previous version of compilers by simple removing problem line of code for recent versions of compilers.

Thank you.