### PR TITLE
[lib/entropy_common] remove checking on error. Change '&' to '&&' at the while loop condition.

### DIFF
--- a/lib/entropy_common.c
+++ b/lib/entropy_common.c
@@ -58,7 +58,6 @@ size_t FSE_readNCount (short* normalizedCounter, unsigned* maxSVPtr, unsigned* t
         memcpy(buffer, headerBuffer, hbSize);
         {   size_t const countSize = FSE_readNCount(normalizedCounter, maxSVPtr, tableLogPtr,
                                                     buffer, sizeof(buffer));
-            if (FSE_isError(countSize)) return countSize;
             if (countSize > hbSize) return ERROR(corruption_detected);
             return countSize;
     }   }
@@ -76,7 +75,7 @@ size_t FSE_readNCount (short* normalizedCounter, unsigned* maxSVPtr, unsigned* t
     threshold = 1<<nbBits;
     nbBits++;
 
-    while ((remaining>1) & (charnum<=*maxSVPtr)) {
+    while ((remaining>1) && (charnum<=*maxSVPtr)) {
         if (previous0) {
             unsigned n0 = charnum;
             while ((bitStream & 0xFFFF) == 0xFFFF) {


### PR DESCRIPTION
Hello.

While reading source code at the repository I detected that, checking at the `FSE_readNCount` function of `lib/entropy_common.c` file on error is not necessary - from the outside of function at least. Because same result will be returned, unless corruption of the data was detected.
Probably possibility to set brake point on that line or addition output from the error function will be the reason to left such checking.

Latter in this function at the while loop condition - placed bit operation instead of checking on logical AND.
Proposed to replaced with the last one.

Thank you.